### PR TITLE
修复深层次view的ajax abort的问题

### DIFF
--- a/src/scripts/modules/spa/1.0.0-rc.4/util/widget.js
+++ b/src/scripts/modules/spa/1.0.0-rc.4/util/widget.js
@@ -1958,8 +1958,7 @@ define('yfjs/spa/util/widget', [
             // destroy included ajax
             $.each(instance.__included__, function(i, included) {
                 if (widget.instanceof(included)) {
-                    Widget.updateState.call(included.getInstance(), 'dispose');
-                    included.ajax.abort(false);
+                    included.dispose();
                 }
             });
 


### PR DESCRIPTION
preView在终止ajax时，只终止了自己与自己的子view，而子view的子view等更深层次的view的ajax请求没有被终止，修复了该问题。