### PR TITLE
修复执行App.go(true, url)时reloadPage参数丢失的问题

### DIFF
--- a/src/scripts/modules/spa/1.0.0-rc.4/app.js
+++ b/src/scripts/modules/spa/1.0.0-rc.4/app.js
@@ -1401,6 +1401,9 @@ define('yfjs/spa/app', [
                 stateHash = state.hash.replace(App.REGEXP_HASH_START, "");
 
                 if (stateHash !== curStateHash) {
+                    if (reloadPage) {
+                        self.go.reloadPage = reloadPage;
+                    }
                     _.def(self.go, '__before_destroy__', true, {
                         configurable: true
                     });
@@ -1427,6 +1430,9 @@ define('yfjs/spa/app', [
                 stateHash = state.hash.replace(App.REGEXP_HASH_START, "");
 
                 if (stateHash !== curStateHash) {
+                    if (reloadPage) {
+                        self.go.reloadPage = reloadPage;
+                    }
                     _.def(self.go, '__before_destroy__', true, {
                         configurable: true
                     });


### PR DESCRIPTION
修复执行App.go(true, url)时，要跳转的url与当前url不同时，执行before_destory后，丢失reloadPage参数的bug